### PR TITLE
Implement Complex Options Aliases

### DIFF
--- a/example/components/validation-example.vue
+++ b/example/components/validation-example.vue
@@ -2,11 +2,16 @@
   <example-block title="Validation" :state="$data">
     <dx-validation-group>
       <dx-text-box value="email@mail.com">
-        <dx-validator :validationRules="validationRules.email" />
+        <dx-validator>
+          <dx-required-rule message="Email is required." />
+          <dx-email-rule message="Email is invalid." />
+        </dx-validator>
       </dx-text-box>
       <br />
       <dx-text-box value="password">
-        <dx-validator :validationRules="validationRules.password" />
+        <dx-validator>
+          <dx-required-rule message="Password is required." />
+        </dx-validator>
       </dx-text-box>
       <br />
       <dx-validation-summary />
@@ -18,7 +23,8 @@
 <script>
 import ExampleBlock from "./example-block";
 
-import { DxButton, DxTextBox, DxValidator, DxValidationGroup, DxValidationSummary } from "../../src";
+import { DxButton, DxTextBox, DxValidationGroup, DxValidationSummary } from "../../src";
+import { DxValidator, DxEmailRule, DxRequiredRule} from "../../src/ui/validator";
 
 export default {
   components: {
@@ -26,6 +32,8 @@ export default {
     DxButton,
     DxTextBox, 
     DxValidator,
+    DxEmailRule,
+    DxRequiredRule,
     DxValidationGroup,
     DxValidationSummary
   },
@@ -35,20 +43,8 @@ export default {
       if (result.isValid) {
           // form data is valid
           params.validationGroup.reset();
-      }     
+      }
     }
-  },
-  data: function() {
-    return {
-      validationRules: {
-        email: [
-            { type: "required", message: "Email is required." },
-            { type: "email", message: "Email is invalid." }
-        ],
-        password: [
-            { type: "required", message: "Password is required." }
-        ]
-    }};
   }
 };
 </script>

--- a/src/core/component.test.ts
+++ b/src/core/component.test.ts
@@ -243,6 +243,32 @@ describe("configuration", () => {
         expect(config.nested[2].collectionItemIndex).toBe(2);
     });
 
+    it("initializes nested config predefined prop", () => {
+        const predefinedValue = {};
+        const NestedWithPredefined = buildTestComponentCtor();
+        (NestedWithPredefined as any as IConfigurationComponent).$_optionName = "nestedOption";
+        (NestedWithPredefined as any as IConfigurationComponent).$_predefinedProps = {
+            predefinedProp: predefinedValue
+        };
+
+        const vm = new Vue({
+            template:
+                `<test-component>` +
+                `  <nested-with-predefined />` +
+                `</test-component>`,
+            components: {
+                TestComponent,
+                NestedWithPredefined
+            }
+        }).$mount();
+
+        const config = (vm.$children[0] as any as IConfigurable).$_config;
+        const initialValues = config.getInitialValues();
+        expect(initialValues).toHaveProperty("nestedOption");
+        expect(initialValues!.nestedOption).toHaveProperty("predefinedProp");
+        expect(initialValues!.nestedOption!.predefinedProp).toBe(predefinedValue);
+    });
+
     it("initializes sub-nested config", () => {
         const subNested = buildTestComponentCtor();
         (subNested as any as IConfigurationComponent).$_optionName = "subNestedOption";

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -142,7 +142,11 @@ function pullConfigurations(children: VNode[], nodes: VNode[], ownerConfig: Conf
             node.componentOptions &&
             (node.componentOptions.Ctor as any as IConfigurationComponent).$_optionName
         ) {
-            const initialValues = { ...node.componentOptions.propsData };
+            const initialValues = {
+                ...(node.componentOptions.Ctor as any as IConfigurationComponent).$_predefinedProps,
+                ...node.componentOptions.propsData
+            };
+
             const config = ownerConfig.createNested(
                 (node.componentOptions.Ctor as any as IConfigurationComponent).$_optionName,
                 initialValues,

--- a/src/core/configuration-component.ts
+++ b/src/core/configuration-component.ts
@@ -8,6 +8,7 @@ import Configuration, { bindOptionWatchers, subscribeOnUpdates } from "./configu
 interface IConfigurationComponent {
     $_optionName: string;
     $_isCollectionItem: boolean;
+    $_predefinedProps: Record<string, any>;
 }
 
 interface IConfigurable {

--- a/tools/integration-data-model.ts
+++ b/tools/integration-data-model.ts
@@ -25,6 +25,7 @@ export interface IComplexProp {
   name: string;
   optionName: string;
   owner: string;
+  predefinedProps: Record<string, any>;
   props: IProp[];
   templates: string[];
 }

--- a/tools/src/component-generator.test.ts
+++ b/tools/src/component-generator.test.ts
@@ -303,7 +303,7 @@ describe("props generation", () => {
         ).toBe(EXPECTED);
     });
 
-    it("renders props without type", () => {
+    it("generates props without type", () => {
         const EXPECTED =
         `    PROP1: {}`;
 
@@ -312,7 +312,7 @@ describe("props generation", () => {
         ).toBe(EXPECTED);
     });
 
-    it("renders props with type", () => {
+    it("generates props with type", () => {
 
       const EXPECTED =
         `    PROP1: TYPE1,` + `\n` +
@@ -324,7 +324,7 @@ describe("props generation", () => {
 
     });
 
-    it("renders props with acceptable values", () => {
+    it("generates props with acceptable values", () => {
         //#region EXPECTED
         const EXPECTED =
 `    PROP1: {
@@ -381,6 +381,154 @@ describe("props generation", () => {
                     isArray: true
                 }
             ])
+        ).toBe(EXPECTED);
+    });
+
+    it("generates nested component with predefined value", () => {
+        //#region EXPECTED
+        const EXPECTED = `
+import * as VueType from "vue";
+const Vue = VueType.default || VueType;
+import WIDGET from "devextreme/DX/WIDGET/PATH";
+import { VueConstructor } from "vue";
+import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
+import { CONFIG_COMPONENT } from "./CONFIG_COMPONENT_PATH";
+
+const COMPONENT: VueConstructor = Vue.extend({
+  extends: BASE_COMPONENT,
+  computed: {
+    instance(): WIDGET {
+      return (this as any).$_instance;
+    }
+  },
+  beforeCreate() {
+    (this as any).$_WidgetClass = WIDGET;
+  }
+});
+
+const NESTED_COMPONENT: any = Vue.extend({
+  extends: CONFIG_COMPONENT,
+  props: {
+    PROP: {}
+  }
+});
+(NESTED_COMPONENT as any).$_optionName = "NESTED_OPTION_NAME";
+(NESTED_COMPONENT as any).$_predefinedProps = {
+  PROP_1: "PREDEFINED_VALUE"
+};
+
+export default COMPONENT;
+export {
+  COMPONENT,
+  NESTED_COMPONENT
+};
+`.trimLeft();
+        //#endregion
+
+        expect(
+            generate({
+                name: "COMPONENT",
+                widgetComponent: {
+                  name: "WIDGET",
+                  path: "DX/WIDGET/PATH"
+                },
+                baseComponent: {
+                    name: "BASE_COMPONENT",
+                    path: "./BASE_COMPONENT_PATH"
+                },
+                configComponent: {
+                    name: "CONFIG_COMPONENT",
+                    path: "./CONFIG_COMPONENT_PATH"
+                },
+                nestedComponents: [
+                  {
+                    name: "NESTED_COMPONENT",
+                    optionName: "NESTED_OPTION_NAME",
+                    props: [
+                      { name: "PROP" }
+                    ],
+                    isCollectionItem: false,
+                    predefinedProps: {
+                      PROP_1: "PREDEFINED_VALUE"
+                    }
+                  }
+                ]
+            })
+        ).toBe(EXPECTED);
+    });
+
+    it("generates nested component with several predefined values", () => {
+        //#region EXPECTED
+        const EXPECTED = `
+import * as VueType from "vue";
+const Vue = VueType.default || VueType;
+import WIDGET from "devextreme/DX/WIDGET/PATH";
+import { VueConstructor } from "vue";
+import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
+import { CONFIG_COMPONENT } from "./CONFIG_COMPONENT_PATH";
+
+const COMPONENT: VueConstructor = Vue.extend({
+  extends: BASE_COMPONENT,
+  computed: {
+    instance(): WIDGET {
+      return (this as any).$_instance;
+    }
+  },
+  beforeCreate() {
+    (this as any).$_WidgetClass = WIDGET;
+  }
+});
+
+const NESTED_COMPONENT: any = Vue.extend({
+  extends: CONFIG_COMPONENT,
+  props: {
+    PROP: {}
+  }
+});
+(NESTED_COMPONENT as any).$_optionName = "NESTED_OPTION_NAME";
+(NESTED_COMPONENT as any).$_predefinedProps = {
+  PROP_1: "PREDEFINED_VALUE_1",
+  PROP_2: "PREDEFINED_VALUE_2"
+};
+
+export default COMPONENT;
+export {
+  COMPONENT,
+  NESTED_COMPONENT
+};
+`.trimLeft();
+        //#endregion
+
+        expect(
+            generate({
+                name: "COMPONENT",
+                widgetComponent: {
+                  name: "WIDGET",
+                  path: "DX/WIDGET/PATH"
+                },
+                baseComponent: {
+                    name: "BASE_COMPONENT",
+                    path: "./BASE_COMPONENT_PATH"
+                },
+                configComponent: {
+                    name: "CONFIG_COMPONENT",
+                    path: "./CONFIG_COMPONENT_PATH"
+                },
+                nestedComponents: [
+                  {
+                    name: "NESTED_COMPONENT",
+                    optionName: "NESTED_OPTION_NAME",
+                    props: [
+                      { name: "PROP" }
+                    ],
+                    isCollectionItem: false,
+                    predefinedProps: {
+                      PROP_1: "PREDEFINED_VALUE_1",
+                      PROP_2: "PREDEFINED_VALUE_2"
+                    }
+                  }
+                ]
+            })
         ).toBe(EXPECTED);
     });
 });

--- a/tools/src/component-generator.ts
+++ b/tools/src/component-generator.ts
@@ -21,6 +21,7 @@ interface INestedComponent {
     optionName: string;
     props: IProp[];
     isCollectionItem: boolean;
+    predefinedProps?: Record<string, any>;
 }
 
 interface INestedComponentModel {
@@ -28,6 +29,10 @@ interface INestedComponentModel {
     optionName: string;
     renderedProps: string;
     isCollectionItem: boolean;
+    predefinedProps: Array<{
+        name: string;
+        value: any;
+    }>;
 }
 
 interface IProp {
@@ -80,13 +85,23 @@ function generate(component: IComponent): string {
 }
 
 function createNestedComponentModel(component: INestedComponent): INestedComponentModel {
+    let predefinedProps;
+
+    if (component.predefinedProps) {
+        predefinedProps = Object.keys(component.predefinedProps).map((name) => ({
+            name,
+            value: component.predefinedProps[name]
+        }));
+    }
+
     return {
         name: component.name,
         optionName: component.optionName,
         renderedProps: component.props
             ? renderProps(component.props)
             : undefined,
-        isCollectionItem: component.isCollectionItem
+        isCollectionItem: component.isCollectionItem,
+        predefinedProps
     };
 }
 
@@ -156,6 +171,14 @@ L1 + `extends: <#= it.baseComponent #>,` +
             `(<#= nested.name #> as any).$_isCollectionItem = true;\n` +
         `<#?#>` +
 
+        `<#? nested.predefinedProps #>` +
+            `(<#= nested.name #> as any).$_predefinedProps = {` +
+            `<#~ nested.predefinedProps : prop #>` +
+                L1 + `<#= prop.name #>: "<#= prop.value #>",` +
+            `<#~#>` + `\b` + `\n` +
+            `};\n` +
+        `<#?#>` +
+
     `<#~#>` +
 `<#?#>` +
 `\n` +
@@ -164,10 +187,10 @@ L1 + `extends: <#= it.baseComponent #>,` +
     `export default <#= it.defaultExport #>;\n` +
 `<#?#>` +
 
-`export {\n` +
+`export {` +
     `<#~ it.namedExports :namedExport #>` +
-    tab(1) + `<#= namedExport #>,\n` +
-    `<#~#>` + `\b\b` + `\n` +
+        L1 + `<#= namedExport #>,` +
+    `<#~#>` + `\b` + `\n` +
 `};\n`
 );
 

--- a/tools/src/generator.ts
+++ b/tools/src/generator.ts
@@ -87,7 +87,8 @@ function mapNestedComponent(complexOption: IComplexProp, customTypes: Record<str
     name: `Dx${uppercaseFirst(complexOption.name)}`,
     optionName: complexOption.optionName,
     props: complexOption.props.map((o) => mapProp(o, customTypes)),
-    isCollectionItem: complexOption.isCollectionItem
+    isCollectionItem: complexOption.isCollectionItem,
+    predefinedProps: complexOption.predefinedProps
   };
 }
 


### PR DESCRIPTION
This adds aliases for options that have several custom types. E.g. several config-components are generated for all the `.validationRules` options (`<DxCompareRule/>`, `<DxCustomRule/>` etc.)
The same for the `dxForm.items` option: `<DxSimpleItem/>`, ... , `<DxGroupItem/>` are generated.

Fixes #140