### PR TITLE
Provide an index for the item templates

### DIFF
--- a/example/app.vue
+++ b/example/app.vue
@@ -46,6 +46,8 @@ import ChartExample from "./components/chart-example";
 import TabPanelExample from "./components/tab-panel-example";
 import FormExample from "./components/form-example";
 
+import config from "../src/core/config";
+config({ useLegacyTemplateEngine: false });
 
 export default {
     components: {

--- a/example/components/form-example.vue
+++ b/example/components/form-example.vue
@@ -29,7 +29,7 @@
             :colSpan="2"
         >
             <dx-text-area
-                slot-scope="data"
+                slot-scope="{ data }"
                 :minHeight="80"
                 :value="data.editorOptions.value"
             />

--- a/example/components/grid-example.vue
+++ b/example/components/grid-example.vue
@@ -73,7 +73,7 @@
         <dx-pager :visible="true" :showPageSizeSelector="true" />
         <dx-paging :pageSize="10"/>
 
-        <dx-button slot="cell-city" slot-scope="data" :text="data.text" />
+        <dx-button slot="cell-city" slot-scope="{ data }" :text="data.text" />
       </dx-data-grid>
     </example-block>
 </template>

--- a/example/components/list-example.vue
+++ b/example/components/list-example.vue
@@ -8,11 +8,11 @@
 
         <h4>List with item template</h4>
         <dx-list :items="listData">
-            <div slot="item" slot-scope="data">
-                <i>{{data.day}}</i>
+            <div slot="item" slot-scope="{ data, index }">
+                {{index + 1}} - <i>{{data.day}}</i>
             </div>
-            <div slot="weekend" slot-scope="data">
-                <i>{{data.day}}</i>
+            <div slot="weekend" slot-scope="{ data, index }">
+                {{index + 1}} - <b>{{data.day}}</b>
             </div>
         </dx-list>
         <br/>
@@ -35,10 +35,10 @@
           itemTemplate="weekday"
           :items="listData"
         >
-            <div slot="weekday" slot-scope="data">
+            <div slot="weekday" slot-scope="{ data }">
                 <s>{{data.day}}</s>
             </div>
-            <div slot="weekend" slot-scope="data">
+            <div slot="weekend" slot-scope="{ data }">
                 <b>{{data.day}}</b>
             </div>
         </dx-list>

--- a/src/core/component.test.ts
+++ b/src/core/component.test.ts
@@ -832,13 +832,14 @@ describe("nested option", () => {
 
 });
 
-function renderTemplate(name: string, model?: object, container?: any): Element {
+function renderTemplate(name: string, model?: object, container?: any, index?: number): Element {
     model = model || {};
     container = container || document.createElement("div");
     const render = WidgetClass.mock.calls[0][1].integrationOptions.templates[name].render;
     return render({
         container,
-        model
+        model,
+        index
     });
 }
 
@@ -846,8 +847,8 @@ describe("template", () => {
 
     const DX_TEMPLATE_WRAPPER = "dx-template-wrapper";
 
-    function renderItemTemplate(model?: object, container?: any): Element {
-        return renderTemplate("item", model, container);
+    function renderItemTemplate(model?: object, container?: any, index?: number): Element {
+        return renderTemplate("item", model, container, index);
     }
 
     it("passes integrationOptions to widget", () => {
@@ -894,14 +895,16 @@ describe("template", () => {
     it("renders scoped slot", () => {
         new Vue({
             template: `<test-component>
-                            <div slot='item' slot-scope='{ data }'>Template {{data.text}}</div>
+                            <div slot='item' slot-scope='{ data: { text }, index }'>
+                                Template {{text}} and index {{index}}
+                            </div>
                         </test-component>`,
             components: {
                 TestComponent
             }
         }).$mount();
-        const renderedTemplate = renderItemTemplate({ text: "with data" });
-        expect(renderedTemplate.innerHTML).toBe("Template with data");
+        const renderedTemplate = renderItemTemplate({ text: "with data" }, undefined, 5);
+        expect(renderedTemplate.innerHTML).toContain("Template with data and index 5");
     });
 
     it("adds templates as children", () => {

--- a/src/core/component.test.ts
+++ b/src/core/component.test.ts
@@ -1,9 +1,12 @@
 import Vue, { VueConstructor } from "vue";
 import { DxComponent, IWidgetComponent } from "../core/component";
+import config from "../core/config";
 import { DxConfiguration, IConfigurable, IConfigurationComponent } from "../core/configuration-component";
 import { DxExtensionComponent } from "../core/extension-component";
 
 import * as events from "devextreme/events";
+
+config({ useLegacyTemplateEngine: false });
 
 const eventHandlers: { [index: string]: (e?: any) => void } = {};
 const Widget = {
@@ -891,7 +894,7 @@ describe("template", () => {
     it("renders scoped slot", () => {
         new Vue({
             template: `<test-component>
-                            <div slot='item' slot-scope='props'>Template {{props.text}}</div>
+                            <div slot='item' slot-scope='{ data }'>Template {{data.text}}</div>
                         </test-component>`,
             components: {
                 TestComponent
@@ -943,7 +946,7 @@ describe("template", () => {
     it("unwraps container", () => {
         new Vue({
             template: `<test-component>
-                            <div slot='item' slot-scope='props'>Template {{props.text}}</div>
+                            <div slot='item' slot-scope='{ data }'>Template {{data.text}}</div>
                         </test-component>`,
             components: {
                 TestComponent

--- a/src/core/component.test.ts
+++ b/src/core/component.test.ts
@@ -1,12 +1,12 @@
 import Vue, { VueConstructor } from "vue";
 import { DxComponent, IWidgetComponent } from "../core/component";
-import config from "../core/config";
+import globalConfig from "../core/config";
 import { DxConfiguration, IConfigurable, IConfigurationComponent } from "../core/configuration-component";
 import { DxExtensionComponent } from "../core/extension-component";
 
 import * as events from "devextreme/events";
 
-config({ useLegacyTemplateEngine: false });
+globalConfig({ useLegacyTemplateEngine: false });
 
 const eventHandlers: { [index: string]: (e?: any) => void } = {};
 const Widget = {

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -4,6 +4,7 @@ import IVue, { VNode, VueConstructor } from "vue";
 import * as events from "devextreme/events";
 
 import { pullAllChildren } from "./children-processing";
+import { getOption } from "./config";
 import Configuration, { bindOptionWatchers, subscribeOnUpdates } from "./configuration";
 import { IConfigurable } from "./configuration-component";
 import { IExtension, IExtensionComponentNode } from "./extension-component";
@@ -191,6 +192,9 @@ const BaseComponent: VueConstructor<IBaseComponent> = Vue.extend({
         $_fillTemplate(template: any, name: string): object {
             return {
                 render: (data: any) => {
+                    const scope = getOption("useLegacyTemplateEngine")
+                        ? data.model
+                        : { data: data.model, index: data.index };
                     const vm = new Vue({
                         name,
                         inject: ["eventBus"],
@@ -200,7 +204,7 @@ const BaseComponent: VueConstructor<IBaseComponent> = Vue.extend({
                                 this.$forceUpdate();
                             });
                         },
-                        render: () => template(data.model)
+                        render: () => template(scope)
                     }).$mount();
 
                     const element = vm.$el;

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -1,0 +1,52 @@
+import Vue from "vue";
+import { DxComponent, IWidgetComponent } from "../core/component";
+import config, { getOption } from "../core/config";
+
+const Widget = {
+    option: jest.fn(),
+    dispose: jest.fn(),
+    on: jest.fn(),
+    fire: jest.fn(),
+    beginUpdate: jest.fn(),
+    endUpdate: jest.fn(),
+};
+
+const WidgetClass = jest.fn(() => Widget);
+
+const TestComponent = Vue.extend({
+    extends: DxComponent,
+    beforeCreate() {
+        (this as any as IWidgetComponent).$_WidgetClass = WidgetClass;
+    }
+});
+
+describe("useLegacyTemplateEngine", () => {
+    const originalValue = getOption("useLegacyTemplateEngine");
+
+    beforeEach(() => {
+        config({ useLegacyTemplateEngine: true });
+    });
+
+    afterEach(() => {
+        config({ useLegacyTemplateEngine: originalValue });
+    });
+
+    it("has model as scope", () => {
+        new Vue({
+            template: `<test-component>
+                            <div slot='item' slot-scope='data'>Template {{data.text}}</div>
+                        </test-component>`,
+            components: {
+                TestComponent
+            }
+        }).$mount();
+
+        const render = WidgetClass.mock.calls[0][1].integrationOptions.templates.item.render;
+        const renderedTemplate = render({
+            container: document.createElement("div"),
+            model: { text: "with data" }
+        });
+
+        expect(renderedTemplate.innerHTML).toBe("Template with data");
+    });
+});

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,0 +1,18 @@
+interface IOptions {
+    useLegacyTemplateEngine: boolean;
+  }
+
+let config: IOptions = {
+    useLegacyTemplateEngine: true
+};
+
+function setOptions(options: Partial<IOptions>): void {
+    config = {...config, ... options};
+}
+
+function getOption<TName extends keyof IOptions>(optionName: TName): IOptions[TName] {
+    return config[optionName];
+}
+
+export default setOptions;
+export { getOption };


### PR DESCRIPTION
Fixes [T726496](https://www.devexpress.com/Support/Center/Question/Details/T726496/there-is-no-way-to-access-the-item-index-in-a-template-in-a-collection-widget).
Config option `useLegacyTemplatEngine` will be set to `false` after all the depended code such as Demos will be prepared.