### PR TITLE
Render templates in DOM

### DIFF
--- a/src/core/component.test.ts
+++ b/src/core/component.test.ts
@@ -1183,6 +1183,46 @@ describe("template", () => {
 
         expect(() => events.triggerHandler(renderedTemplate, "dxremove")).not.toThrow();
     });
+
+    describe("with DOM", () => {
+        let fixture;
+
+        beforeEach(() => {
+            fixture = document.createElement("div");
+            document.body.appendChild(fixture);
+        });
+
+        afterEach(() => {
+            fixture.remove();
+        });
+
+        it("template content should be rendered in DOM", () => {
+            let mountedInDom;
+            const ChildComponent = Vue.extend({
+                template: "<div></div>",
+                mounted() {
+                    mountedInDom = document.body.contains(this.$el);
+                }
+            });
+            const instance = new Vue({
+                el: fixture,
+                template: `<test-component ref="component">
+                                <div class="template-container"></div>
+                                <template #tmpl>
+                                    <child-component/>
+                                </template>
+                            </test-component>`,
+                components: {
+                    TestComponent,
+                    ChildComponent
+                }
+            }).$mount();
+
+            renderTemplate("tmpl", {}, instance.$el.querySelector(".template-container"));
+
+            expect(mountedInDom).toBeTruthy();
+        });
+    });
 });
 
 describe("static items", () => {

--- a/src/core/component.ts
+++ b/src/core/component.ts
@@ -203,15 +203,15 @@ const BaseComponent: VueConstructor<IBaseComponent> = Vue.extend({
                         ? data.model
                         : { data: data.model, index: data.index };
 
-                    const mountedTemplate = mountTemplate(template, this, scopeData, name);
+                    const container = data.container.get ? data.container.get(0) : data.container;
+                    const placeholder = document.createElement("div");
+                    container.appendChild(placeholder);
+                    const mountedTemplate = mountTemplate(template, this, scopeData, name, placeholder);
 
                     const element = mountedTemplate.$el;
                     if (element.classList) {
                         element.classList.add(DX_TEMPLATE_WRAPPER_CLASS);
                     }
-
-                    const container = data.container.get ? data.container.get(0) : data.container;
-                    container.appendChild(element);
 
                     events.one(element, DX_REMOVE_EVENT, mountedTemplate.$destroy.bind(mountedTemplate));
 

--- a/src/core/templates-discovering.ts
+++ b/src/core/templates-discovering.ts
@@ -66,9 +66,11 @@ function mountTemplate(
     template: ScopedSlot,
     parent: IVue,
     data: any,
-    name: string
+    name: string,
+    placeholder: Element
 ): IVue {
     return new Vue({
+        el: placeholder,
         name,
         inject: ["eventBus"],
         parent,
@@ -89,7 +91,7 @@ function mountTemplate(
 
             return content[0];
         }
-    }).$mount();
+    });
 }
 
 export {


### PR DESCRIPTION
Fixes [T732578](https://www.devexpress.com/Support/Center/Question/Details/T732578/accordion-the-initial-rendering-layout-in-the-drawer-container-is-incorrect) and [T749050](https://www.devexpress.com/Support/Center/Question/Details/T749050/dxhtmleditor-inside-a-dxlist-item-template-cannot-render-paragraphs).