### PR TITLE
Fix merging constructors with options interfaces

### DIFF
--- a/tools/src/component-generator.test.ts
+++ b/tools/src/component-generator.test.ts
@@ -6,13 +6,12 @@ it("generates", () => {
 import * as VueType from "vue";
 const Vue = VueType.default || VueType;
 import WIDGET from "devextreme/DX/WIDGET/PATH";
-import { VueConstructor } from "vue";
 import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
 
-interface COMPONENT extends VueConstructor {
+interface COMPONENT {
   readonly instance?: WIDGET;
 }
-const COMPONENT: COMPONENT = Vue.extend({
+const COMPONENT = Vue.extend({
   extends: BASE_COMPONENT,
   computed: {
     instance(): WIDGET {
@@ -57,13 +56,12 @@ it("generates component with model", () => {
 import * as VueType from "vue";
 const Vue = VueType.default || VueType;
 import WIDGET from "devextreme/DX/WIDGET/PATH";
-import { VueConstructor } from "vue";
 import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
 
-interface COMPONENT extends VueConstructor {
+interface COMPONENT {
   readonly instance?: WIDGET;
 }
-const COMPONENT: COMPONENT = Vue.extend({
+const COMPONENT = Vue.extend({
   extends: BASE_COMPONENT,
   model: { prop: "value", event: "update:value" },
   computed: {
@@ -110,17 +108,16 @@ it("generates option", () => {
 import * as VueType from "vue";
 const Vue = VueType.default || VueType;
 import WIDGET, { IOptions } from "devextreme/DX/WIDGET/PATH";
-import { VueConstructor } from "vue";
 import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
 
 type AccessibleOptions = Pick<IOptions,
   "PROP"
 >;
 
-interface COMPONENT extends VueConstructor, AccessibleOptions {
+interface COMPONENT extends AccessibleOptions {
   readonly instance?: WIDGET;
 }
-const COMPONENT: COMPONENT = Vue.extend({
+const COMPONENT = Vue.extend({
   extends: BASE_COMPONENT,
   props: {
     PROP: {}
@@ -169,14 +166,13 @@ it("generates nested option component", () => {
 import * as VueType from "vue";
 const Vue = VueType.default || VueType;
 import WIDGET from "devextreme/DX/WIDGET/PATH";
-import { VueConstructor } from "vue";
 import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
 import { CONFIG_COMPONENT } from "./CONFIG_COMPONENT_PATH";
 
-interface COMPONENT extends VueConstructor {
+interface COMPONENT {
   readonly instance?: WIDGET;
 }
-const COMPONENT: COMPONENT = Vue.extend({
+const COMPONENT = Vue.extend({
   extends: BASE_COMPONENT,
   computed: {
     instance(): WIDGET {
@@ -241,14 +237,13 @@ it("generates nested collection option component", () => {
 import * as VueType from "vue";
 const Vue = VueType.default || VueType;
 import WIDGET from "devextreme/DX/WIDGET/PATH";
-import { VueConstructor } from "vue";
 import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
 import { CONFIG_COMPONENT } from "./CONFIG_COMPONENT_PATH";
 
-interface COMPONENT extends VueConstructor {
+interface COMPONENT {
   readonly instance?: WIDGET;
 }
-const COMPONENT: COMPONENT = Vue.extend({
+const COMPONENT = Vue.extend({
   extends: BASE_COMPONENT,
   computed: {
     instance(): WIDGET {
@@ -314,14 +309,13 @@ it("generates expectedChildren info", () => {
 import * as VueType from "vue";
 const Vue = VueType.default || VueType;
 import WIDGET from "devextreme/DX/WIDGET/PATH";
-import { VueConstructor } from "vue";
 import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
 import { CONFIG_COMPONENT } from "./CONFIG_COMPONENT_PATH";
 
-interface COMPONENT extends VueConstructor {
+interface COMPONENT {
   readonly instance?: WIDGET;
 }
-const COMPONENT: COMPONENT = Vue.extend({
+const COMPONENT = Vue.extend({
   extends: BASE_COMPONENT,
   computed: {
     instance(): WIDGET {
@@ -502,14 +496,13 @@ describe("props generation", () => {
 import * as VueType from "vue";
 const Vue = VueType.default || VueType;
 import WIDGET from "devextreme/DX/WIDGET/PATH";
-import { VueConstructor } from "vue";
 import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
 import { CONFIG_COMPONENT } from "./CONFIG_COMPONENT_PATH";
 
-interface COMPONENT extends VueConstructor {
+interface COMPONENT {
   readonly instance?: WIDGET;
 }
-const COMPONENT: COMPONENT = Vue.extend({
+const COMPONENT = Vue.extend({
   extends: BASE_COMPONENT,
   computed: {
     instance(): WIDGET {
@@ -580,14 +573,13 @@ export {
 import * as VueType from "vue";
 const Vue = VueType.default || VueType;
 import WIDGET from "devextreme/DX/WIDGET/PATH";
-import { VueConstructor } from "vue";
 import { BASE_COMPONENT } from "./BASE_COMPONENT_PATH";
 import { CONFIG_COMPONENT } from "./CONFIG_COMPONENT_PATH";
 
-interface COMPONENT extends VueConstructor {
+interface COMPONENT {
   readonly instance?: WIDGET;
 }
-const COMPONENT: COMPONENT = Vue.extend({
+const COMPONENT = Vue.extend({
   extends: BASE_COMPONENT,
   computed: {
     instance(): WIDGET {

--- a/tools/src/component-generator.ts
+++ b/tools/src/component-generator.ts
@@ -77,10 +77,6 @@ function generate(component: IComponent): string {
 
     const namedExports: string[] = [component.name];
     const namedImports = [
-        {
-            name: "VueConstructor",
-            path: "vue"
-        },
         component.baseComponent
     ];
 
@@ -176,11 +172,11 @@ const renderComponent: (model: {
     `\n` +
 `<#?#>` +
 
-`interface <#= it.component #> extends VueConstructor<#? it.props #>, AccessibleOptions<#?#> {` +
+`interface <#= it.component #><#? it.props #> extends AccessibleOptions<#?#> {` +
     L1 + `readonly instance?: <#= it.widgetImport.name #>;` + `\n` +
 `}` + `\n` +
 
-`const <#= it.component #>: <#= it.component #> = Vue.extend({` +
+`const <#= it.component #> = Vue.extend({` +
 L1 + `extends: <#= it.baseComponent #>,` +
 
 `<#? it.props #>` +


### PR DESCRIPTION
This resolves names conflict for the `dxSortable.filter` option.
The TS declaration is changed this way:

```diff
import * as VueType from "vue";
const Vue = VueType.default || VueType;
import Sortable, { IOptions } from "devextreme/ui/sortable";
import { DxComponent } from "./core/component";

type AccessibleOptions = Pick<IOptions,
  "boundary" |
  "container" |
  "dragDirection" |
  "elementAttr" |
  "filter" |
   ....
>;

-interface DxSortable extends VueConstructor, AccessibleOptions {
+interface DxSortable extends AccessibleOptions {
  readonly instance?: Sortable;
}
-const DxSortable : DxSortable = Vue.extend({
+const DxSortable = Vue.extend({
  extends: DxComponent,
  props: {
    ....
    filter: String,
    ....
  },
  computed: {
    instance(): Sortable {
      return (this as any).$_instance;
    }
  },
  beforeCreate() {
    (this as any).$_WidgetClass = Sortable;
  }
});

export default DxSortable;
export {
  DxSortable
};
```